### PR TITLE
Add ONNX export instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,32 @@ python test_images.py
 python train.py --training_dir --data-name --test-name
 ```
 
+## Exporting to ONNX
+The pretrained model can be converted to an ONNX file for C++ deployment. After
+downloading the checkpoint into `./model/`, run:
+
+```bash
+python export_onnx.py --weights ./model/<folder>/best_model.tar --output wbflow.onnx
+```
+
+This generates `wbflow.onnx` which can be loaded by ONNX Runtime.
+
+## Running inference in C++
+Download the prebuilt ONNX Runtime package and build the example:
+
+```bash
+# get ONNX Runtime
+curl -L https://github.com/microsoft/onnxruntime/releases/download/v1.17.0/onnxruntime-linux-x64-1.17.0.tgz \
+  | tar xz
+# compile the demo
+g++ onnx_inference.cpp \
+    -I onnxruntime-linux-x64-1.17.0/include \
+    -L onnxruntime-linux-x64-1.17.0/lib -lonnxruntime \
+    -o onnx_inference
+# run it
+LD_LIBRARY_PATH=onnxruntime-linux-x64-1.17.0/lib ./onnx_inference wbflow.onnx
+```
+
 # Citation
 * Paper is available: [paper link](https://github.com/ChunxiaoLe/SWBNet/blob/master/paper/9786.ChunxiaoLi.pdf)
 * Citing format is coming soon...

--- a/export_onnx.py
+++ b/export_onnx.py
@@ -1,0 +1,49 @@
+import argparse
+import torch
+from glow_wb import Camera_Glow_norev_re
+from torch import nn
+
+class WBFlowWrapper(nn.Module):
+    def __init__(self, glow_model):
+        super().__init__()
+        self.glow = glow_model
+
+    def forward(self, img, camidx):
+        z = self.glow(img, camidx, forward=True)
+        out = self.glow(z, camidx, forward=False)
+        return out
+
+def main():
+    parser = argparse.ArgumentParser(description="Export WBFlow model to ONNX")
+    parser.add_argument('--weights', required=True, help='Path to pretrained checkpoint')
+    parser.add_argument('--output', default='wbflow.onnx', help='Output ONNX file')
+    parser.add_argument('--opset', type=int, default=11, help='ONNX opset version')
+    args = parser.parse_args()
+
+    device = torch.device('cpu')
+    model = Camera_Glow_norev_re(3, 15, n_flow=8, n_block=2, affine=False, conv_lu=True)
+    checkpoint = torch.load(args.weights, map_location=device)
+    model.load_state_dict(checkpoint['state_dict'])
+    model.to(device).eval()
+
+    wrapped = WBFlowWrapper(model)
+
+    dummy_img = torch.randn(1, 3, 256, 256, device=device)
+    dummy_cam = torch.zeros(1, 15, 1, 1, device=device)
+    torch.onnx.export(
+        wrapped,
+        (dummy_img, dummy_cam),
+        args.output,
+        input_names=['input', 'camidx'],
+        output_names=['output'],
+        dynamic_axes={
+            'input': {0: 'batch', 2: 'height', 3: 'width'},
+            'camidx': {0: 'batch'},
+            'output': {0: 'batch', 2: 'height', 3: 'width'}
+        },
+        opset_version=args.opset,
+    )
+    print(f"ONNX model saved to {args.output}")
+
+if __name__ == '__main__':
+    main()

--- a/onnx_inference.cpp
+++ b/onnx_inference.cpp
@@ -1,0 +1,39 @@
+#include <onnxruntime_cxx_api.h>
+#include <vector>
+#include <array>
+#include <iostream>
+
+int main(int argc, char* argv[]) {
+    if (argc < 2) {
+        std::cout << "Usage: " << argv[0] << " <model.onnx>" << std::endl;
+        return 1;
+    }
+
+    const char* model_path = argv[1];
+
+    Ort::Env env(ORT_LOGGING_LEVEL_WARNING, "wbflow");
+    Ort::SessionOptions session_options;
+    Ort::Session session(env, model_path, session_options);
+
+    std::vector<int64_t> input_shape{1, 3, 256, 256};
+    std::vector<float> image_data(input_shape[1] * input_shape[2] * input_shape[3], 0.5f);
+
+    std::vector<int64_t> cam_shape{1, 15, 1, 1};
+    std::vector<float> cam_data(15, 0.f);
+    cam_data[0] = 1.f; // example: first camera index
+
+    auto memory_info = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
+    Ort::Value img_tensor = Ort::Value::CreateTensor<float>(memory_info, image_data.data(), image_data.size(), input_shape.data(), input_shape.size());
+    Ort::Value cam_tensor = Ort::Value::CreateTensor<float>(memory_info, cam_data.data(), cam_data.size(), cam_shape.data(), cam_shape.size());
+
+    const char* input_names[] = {"input", "camidx"};
+    const char* output_names[] = {"output"};
+    std::array<Ort::Value, 2> inputs = {std::move(img_tensor), std::move(cam_tensor)};
+
+    auto outputs = session.Run(Ort::RunOptions{}, input_names, inputs.data(), inputs.size(), output_names, 1);
+
+    float* result = outputs.front().GetTensorMutableData<float>();
+    std::cout << "First output value: " << result[0] << std::endl;
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add script to convert pretrained model to ONNX format
- document ONNX export in README
- add sample C++ inference code and usage instructions

## Testing
- `python -m py_compile export_onnx.py`
- `g++ onnx_inference.cpp -Ideps/onnxruntime-linux-x64-1.17.0/include -Ldeps/onnxruntime-linux-x64-1.17.0/lib -lonnxruntime -o onnx_inference`
- `LD_LIBRARY_PATH=deps/onnxruntime-linux-x64-1.17.0/lib ./onnx_inference`

------
https://chatgpt.com/codex/tasks/task_e_688858f3ed208332b91d586af43f7ae1